### PR TITLE
docs: adds contributors guide so contributors can add posts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,10 @@
+# How to add a post 
+
+1. Open a feature branch against [LoC digital garden](https://github.com/LadiesOfCodeGroupSessions/loc-digital-garden)
+2. Make a copy of the [template file](src/content/template.md)
+3. Rename the copied file to be the name of the post and fill in the example metadata fields with the correct data for your post. Add the content of your post below the metadata fields.
+4. Commit and push your changes to the feature branch.
+5. If you'd like to check how the post would look, you can follow the instructions in the [README](README.md) to run the app locally.
+6. Open the PR to be reviewed.
+7. Once the PR has been reviewed and approved, merge the PR.
+8. The content should appear on the site.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,8 +3,9 @@
 1. Open a feature branch against [LoC digital garden](https://github.com/LadiesOfCodeGroupSessions/loc-digital-garden)
 2. Make a copy of the [template file](src/content/template.md)
 3. Rename the copied file to be the name of the post and fill in the example metadata fields with the correct data for your post. Add the content of your post below the metadata fields.
-4. Commit and push your changes to the feature branch.
-5. If you'd like to check how the post would look, you can follow the instructions in the [README](README.md) to run the app locally.
-6. Open the PR to be reviewed.
-7. Once the PR has been reviewed and approved, merge the PR.
-8. The content should appear on the site.
+4. Add your file name to index file [index.md](src/content/index.md), following the example of the template entry
+5. Commit and push your changes to the feature branch.
+6. If you'd like to check how the post would look, you can follow the instructions in the [README](README.md) to run the app locally.
+7. Open the PR to be reviewed.
+8. Once the PR has been reviewed and approved, merge the PR.
+9. The content should appear on the site.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - [Ladies of Code Digitial Garden](#ladies-of-code-digitial-garden)
   - [About](#about)
+  - [Adding a post to the Digital Garden](#adding-a-post-to-the-digital-garden)
   - [Setup](#setup)
   - [Run locally](#run-locally)
   - [See how the site looks in production](#see-how-the-site-looks-in-production)
@@ -13,6 +14,9 @@
 
 This project is set up using [nuxt 3](https://v3.nuxtjs.org). Find out more about the ambitions for this project [here](https://ladiesofcodegroupsessions.github.io/).
 
+## Adding a post to the Digital Garden
+
+If you'd like to add a post to the Digital Garden, please follow the instructions in the [CONTRIBUTORS](CONTRIBUTORS.md) file.
 ## Setup
 
 1. Ensure you have the minimum versions of npm and node as specified in the [package.json](./package.json) `engines` section.

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -1,6 +1,5 @@
 ---
-title: 'test'
+title: 'Posts'
 ---
-some more content
 
 [/template](/template)


### PR DESCRIPTION
# What this does

Adds guidance for contributors to be able to add posts 

## Our checklist

- [x] Commit message

## More information

- [x] [Github Issue](https://github.com/LadiesOfCodeGroupSessions/loc-digital-garden/issues/15)

