### PR TITLE
docs: add reference to deployed site

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,4 +8,4 @@
 6. If you'd like to check how the post would look, you can follow the instructions in the [README](README.md) to run the app locally.
 7. Open the PR to be reviewed.
 8. Once the PR has been reviewed and approved, merge the PR.
-9. The content should appear on the site.
+9. The content should appear on the site [here](https://ladies-of-code-digital-garden.netlify.app/) after merging.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 This project is set up using [nuxt 3](https://v3.nuxtjs.org). Find out more about the ambitions for this project [here](https://ladiesofcodegroupsessions.github.io/).
 
+You can see the site [here](https://ladies-of-code-digital-garden.netlify.app/)
+
 ## Adding a post to the Digital Garden
 
 If you'd like to add a post to the Digital Garden, please follow the instructions in the [CONTRIBUTORS](CONTRIBUTORS.md) file.


### PR DESCRIPTION
# What this does
Adds reference to the deployed site. Also tests if netlify retriggers a deploy automatically after merging to main. 

## Our checklist

- [x] Commit message


## More information

- [x] [Github Issue](https://github.com/LadiesOfCodeGroupSessions/loc-digital-garden/issues/5)

